### PR TITLE
2023 update: remove httpd:2.4 container image reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,5 +243,3 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-
-.fake

--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,5 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+.fake

--- a/ecs-cluster-setup.yaml
+++ b/ecs-cluster-setup.yaml
@@ -209,7 +209,7 @@ Resources:
       - Name: simple-app
         Cpu: '10'
         Essential: 'true'
-        Image: httpd:2.4
+        Image: <REPLACE with Apache container image>
         Memory: '300'
         LogConfiguration:
           LogDriver: awslogs

--- a/ecs-cluster-setup.yaml
+++ b/ecs-cluster-setup.yaml
@@ -31,6 +31,9 @@ Parameters:
       c3.2xlarge, c3.4xlarge, c3.8xlarge, r3.large, r3.xlarge, r3.2xlarge, r3.4xlarge,
       r3.8xlarge, i2.xlarge, i2.2xlarge, i2.4xlarge, i2.8xlarge]
     ConstraintDescription: Please choose at least an m3.medium instance type.
+  BucketName:
+    Type: String
+    Description: The name of the S3 bucket used to store lambda for deployment.
 Mappings:
   CidrMappings:
     public-subnet-1:
@@ -154,6 +157,14 @@ Resources:
     Type: AWS::EC2::SecurityGroup
   DemoS3Bucket:
     Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: !Ref BucketName
+      BucketEncryption:
+        ServerSideEncryptionConfiguration: 
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
   ECSCluster:
     Type: AWS::ECS::Cluster
   EcsSecurityGroup:

--- a/ecs-task-rebalancer.py
+++ b/ecs-task-rebalancer.py
@@ -49,11 +49,20 @@ def lambda_handler(event, context):
     # Rebalance ECS tasks of all services deployed in the cluster
     def rebalance_tasks():
         all_services = get_cluster_services()
+        for service in all_services:
+            print("Rebalancing tasks for service: " + service)
+            response = ecs.update_service(
+                cluster=cluster_name,
+                service=service,
+                forceNewDeployment=True
+            )
 
         # For each service, figure out the taskDefinition, register a new version
         # and update the service -- This sequence will rebalance the tasks on all
         # available and connected instances
-        response = ecs.describe_services(
+
+
+"""         response = ecs.describe_services(
             cluster=cluster_name,
             services=all_services
         )
@@ -112,7 +121,7 @@ def lambda_handler(event, context):
 
     containerInstances = response["containerInstances"]
     print(f"Number of container instances {len(containerInstances)}")
-    if(len(containerInstances) != 0):
+    if (len(containerInstances) != 0):
         containerInstance = containerInstances[0]
         numberOfRunningTasks = containerInstance["runningTasksCount"]
         numberOfPendingTasks = containerInstance["pendingTasksCount"]
@@ -122,3 +131,4 @@ def lambda_handler(event, context):
             rebalance_tasks()
         else:
             print("Event does not warrant task rebalancing.")
+ """


### PR DESCRIPTION
Removing the httpd:2.4 image temporarily. Will update with new image soon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
